### PR TITLE
Implemented a daily system job handling record expiration

### DIFF
--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -120,6 +120,7 @@ class DNSConfig(PluginConfig):
     def ready(self):
         super().ready()
 
+        import netbox_dns.jobs.record_expiration  # noqa: F401
         import netbox_dns.signals.dnssec  # noqa: F401
 
         if not get_plugin_config("netbox_dns", "dnssync_disabled"):

--- a/netbox_dns/jobs/__init__.py
+++ b/netbox_dns/jobs/__init__.py
@@ -1,0 +1,1 @@
+from .record_expiration import *

--- a/netbox_dns/jobs/record_expiration.py
+++ b/netbox_dns/jobs/record_expiration.py
@@ -1,0 +1,44 @@
+from datetime import date, datetime
+
+from django.db.models import F
+from django.utils.translation import gettext_lazy as _
+
+from core.choices import JobIntervalChoices
+from netbox.jobs import JobRunner, system_job
+from netbox_dns.models import Record
+
+
+@system_job(interval=JobIntervalChoices.INTERVAL_DAILY)
+class RecordExpirationJob(JobRunner):
+    class Meta:
+        name = "Handle expired records"
+
+    def run(self, *args, **kwargs):
+        self.logger.info(_("Checking record expiration"))
+
+        expired_records = Record.objects.filter(
+            expiration_date__isnull=False,
+            expiration_date__lte=date.today(),
+            expiration_date__gte=F("last_updated"),
+        )
+
+        if not expired_records.exists():
+            self.logger.info(_("No expired records found"))
+            return
+
+        update_zones = set()
+
+        for record in expired_records:
+            self.logger.info(
+                _("Updating expired record {record}").format(record=record)
+            )
+
+            update_zones.add(record.zone)
+
+            record.last_updated = datetime.now()
+            super(Record, record).save()
+
+        for zone in update_zones:
+            self.logger.info(_("Updating SOA_SERIAL for zone {zone}").format(zone=zone))
+
+            zone.update_serial()


### PR DESCRIPTION
The new record expiration feature can only work if the SOA SERIAL number for a zone is updated when a record expires. 

This PR implements a system job that runs once per day and finds records that have an expiry date that is in the past, but after the date the record was last changed. If it finds such a record, it updates the `last_changed` field of the record and recalculates the SOA SERIAL fields of all zones affected.