### PR TITLE
Removed redundant expiration warning for records

### DIFF
--- a/netbox_dns/templates/netbox_dns/record.html
+++ b/netbox_dns/templates/netbox_dns/record.html
@@ -122,12 +122,6 @@
                         <th scope="row">{% trans "Expiration Date" %}</th>
                         <td>{{ object.expiration_date|isodate }}</td>
                     </tr>
-                    {% if expiration_warning %}
-                        <tr class="text-warning">
-                            <th scope="row">{% trans "Warning" %}</th>
-                            <td>{{ expiration_warning }}</td>
-                        </tr>
-                    {% endif %}
                 {% endif %}
                 {% if object.ptr_record %}
                 <tr>

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -172,9 +172,6 @@ class RecordView(generic.ObjectView):
 
             context["rrset_record_table"] = rrset_record_table
 
-        if instance.expiration_date is not None and instance.is_expired:
-            context["expiration_warning"] = _("Record is expired")
-
         if not instance.managed:
             try:
                 instance.check_zone_cut_conflict()


### PR DESCRIPTION
The explicit warning that a record is expired is somewhat redundant to the "expired" status, so it was removed.