### PR TITLE
Use bulk update in migration 0023 instead of per-row save()

### DIFF
--- a/netbox_dns/migrations/0023_disable_ptr_false.py
+++ b/netbox_dns/migrations/0023_disable_ptr_false.py
@@ -2,18 +2,17 @@
 
 from django.db import migrations
 
-from netbox_dns.choices import RecordTypeChoices
-
 
 def set_disable_ptr_false(apps, schema_editor):
     Record = apps.get_model("netbox_dns", "Record")
 
-    for record in Record.objects.exclude(
-        type__in=(RecordTypeChoices.A, RecordTypeChoices.AAAA)
-    ):
-        if record.disable_ptr:
-            record.disable_ptr = False
-            record.save()
+    Record.objects.filter(
+        disable_ptr=True,
+    ).exclude(
+        type__in=("A", "AAAA"),
+    ).update(
+        disable_ptr=False,
+    )
 
 
 class Migration(migrations.Migration):
@@ -22,5 +21,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(set_disable_ptr_false),
+        migrations.RunPython(
+            set_disable_ptr_false,
+            reverse_code=migrations.RunPython.noop,
+        ),
     ]


### PR DESCRIPTION
fixes: #844

## Summary

Optimizes data migration `0023_disable_ptr_false` to use a single bulk
`UPDATE` instead of iterating over records and calling `save()` one at a time.

## Changes

- Replace the per-row loop with a single filtered queryset `update()`.
- Filter on `disable_ptr=True` at the database level so only affected rows are touched.
- Inline the `"A"` / `"AAAA"` type literals and drop the `RecordTypeChoices` import, keeping the migration self-contained.
- Add `reverse_code=migrations.RunPython.noop` to make the migration reversible.

## Why

The original implementation loaded every non-A/AAAA record into memory and
issued one query per row. The new version runs a single SQL statement,
which is significantly faster on large `Record` tables and avoids
unnecessary ORM overhead.

## Notes

No functional change to the end result — the same records end up with
`disable_ptr=False`.