### PR TITLE
Show tooltips for truncated record values in tables

### DIFF
--- a/netbox_dns/tables/record.py
+++ b/netbox_dns/tables/record.py
@@ -47,13 +47,17 @@ class RecordBaseTable(TenancyColumnsMixin, PrimaryModelTable):
         verbose_name=_("Value"),
         template_code="""
             <span title="{{ value }}">
-               {{ value|truncatechars:64 }}
+               {{ value|truncatechars:48 }}
             </span>
         """,
     )
     unicode_value = TemplateColumn(
         verbose_name=_("Unicode Value"),
-        template_code="{{ value|truncatechars:64 }}",
+        template_code="""
+            <span title="{{ value }}">
+               {{ value|truncatechars:48 }}
+            </span>
+        """,
         accessor="value",
     )
     ttl = tables.Column(

--- a/netbox_dns/tables/record.py
+++ b/netbox_dns/tables/record.py
@@ -45,7 +45,11 @@ class RecordBaseTable(TenancyColumnsMixin, PrimaryModelTable):
     )
     value = TemplateColumn(
         verbose_name=_("Value"),
-        template_code="{{ value|truncatechars:64 }}",
+        template_code="""
+            <span title="{{ value }}">
+               {{ value|truncatechars:64 }}
+            </span>
+        """,
     )
     unicode_value = TemplateColumn(
         verbose_name=_("Unicode Value"),

--- a/netbox_dns/tables/record_template.py
+++ b/netbox_dns/tables/record_template.py
@@ -48,11 +48,19 @@ class RecordTemplateTable(TenancyColumnsMixin, PrimaryModelTable):
     )
     value = TemplateColumn(
         verbose_name=_("Value"),
-        template_code="{{ value|truncatechars:64 }}",
+        template_code="""
+            <span title="{{ value }}">
+               {{ value|truncatechars:48 }}
+            </span>
+        """,
     )
     unicode_value = TemplateColumn(
         verbose_name=_("Unicode Value"),
-        template_code="{{ value|truncatechars:64 }}",
+        template_code="""
+            <span title="{{ value }}">
+               {{ value|truncatechars:48 }}
+            </span>
+        """,
         accessor="value",
     )
     ttl = tables.Column(


### PR DESCRIPTION
Added tooltips for long values and truncated the values to 48 instead of 64 chars to save column width

Fixes #848