### PR TITLE
Add date-counter format for automatic SOA serials

### DIFF
--- a/docs/using_netbox_dns.md
+++ b/docs/using_netbox_dns.md
@@ -335,7 +335,21 @@ SOA SERIAL fields are crucial for the propagation of zone data from primary name
 
 This is particularly relevant when PTR records are automatically created from A and AAAA records and an update to a forward zone thus can result in one or several reverse zones being updated in the background as well.
 
-For that reason, NetBox DNS offers the option of automatically creating SOA serial numbers when zones or records within them change. This is controlled by the `Generate SOA Serial` checkbox in the zone create and edit views. If that check box is ticked, the serial number of the zone is calculated as maximum of the Unix epoch times (seconds since January 1st, 1970 00:00 UTC) of the last change to any records and the zone itself.
+For that reason, NetBox DNS offers the option of automatically creating SOA serial numbers when zones or records within them change. This is controlled by the `Generate SOA Serial` checkbox in the zone create and edit views. If that check box is ticked, the serial number defaults to the maximum of the Unix epoch times (seconds since January 1st, 1970 00:00 UTC) of the last change to any records and the zone itself.
+
+The plugin setting `zone_soa_serial_format` can be set to `date-counter` to
+generate serials in `YYYYMMDDnn` format instead. `nn` starts at `00` each day
+and is increased for every subsequent zone change on that day, allowing up to
+100 changes per zone and day. The default value is `unix`, which retains the
+existing behaviour.
+
+```python
+PLUGINS_CONFIG = {
+    "netbox_dns": {
+        "zone_soa_serial_format": "date-counter",
+    }
+}
+```
 
 If the checkbox is not selected, the SERIAL field is mandatory and the user is responsible for keeping track of zone changes. NetBox DNS will not touch the serial number of that zone in any case.
 

--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -25,6 +25,7 @@ class DNSConfig(PluginConfig):
         "zone_default_ttl": 86400,
         "zone_soa_ttl": 86400,
         "zone_soa_serial": 1,
+        "zone_soa_serial_format": "unix",
         "zone_soa_refresh": 43200,
         "zone_soa_retry": 7200,
         "zone_soa_expire": 2419200,
@@ -140,6 +141,12 @@ class DNSConfig(PluginConfig):
             "custom_record_types",
         ):
             _check_list(setting)
+
+        soa_serial_format = get_plugin_config("netbox_dns", "zone_soa_serial_format")
+        if soa_serial_format not in ("unix", "date-counter"):
+            raise ImproperlyConfigured(
+                "zone_soa_serial_format must be 'unix' or 'date-counter'"
+            )
 
 
 #

--- a/netbox_dns/models/zone.py
+++ b/netbox_dns/models/zone.py
@@ -695,7 +695,27 @@ class Zone(ObjectModificationMixin, ContactsMixin, PrimaryModel):
         if self.last_updated:
             soa_serial = ceil(max(soa_serial, self.last_updated.timestamp()))
 
-        return soa_serial
+        return self.format_auto_serial(soa_serial)
+
+    def format_auto_serial(self, timestamp):
+        if get_plugin_config("netbox_dns", "zone_soa_serial_format") == "date-counter":
+            date_serial = int(datetime.fromtimestamp(timestamp).strftime("%Y%m%d00"))
+            if self.soa_serial is not None and date_serial <= self.soa_serial < (
+                date_serial + 99
+            ):
+                return self.soa_serial + 1
+            if self.soa_serial == date_serial + 99:
+                raise ValidationError(
+                    {
+                        "soa_serial": _(
+                            "The daily limit of 100 automatic SOA serial numbers "
+                            "has been reached for zone {zone}."
+                        ).format(zone=self.name)
+                    }
+                )
+            return date_serial
+
+        return ceil(timestamp)
 
     def update_serial(self, save_zone_serial=True):
         if not self.soa_serial_auto:
@@ -703,7 +723,7 @@ class Zone(ObjectModificationMixin, ContactsMixin, PrimaryModel):
 
         self.snapshot()
         self.last_updated = datetime.now()
-        self.soa_serial = ceil(datetime.now().timestamp())
+        self.soa_serial = self.format_auto_serial(datetime.now().timestamp())
 
         if save_zone_serial:
             super().save(update_fields=["soa_serial", "last_updated"])

--- a/netbox_dns/tests/zone/test_auto_soa_serial.py
+++ b/netbox_dns/tests/zone/test_auto_soa_serial.py
@@ -91,6 +91,56 @@ class ZoneAutoSOASerialTestCase(TestCase):
 
         self.assertEqual(zone.soa_serial, 1)
 
+    @override_settings(
+        PLUGINS_CONFIG={
+            "netbox_dns": {
+                **settings.PLUGINS_CONFIG["netbox_dns"],
+                "zone_soa_serial_format": "date-counter",
+            }
+        }
+    )
+    def test_date_counter_soa_serial(self):
+        zone = self.zones[0]
+        today = int(datetime.now().strftime("%Y%m%d00"))
+        zone.soa_serial = None
+
+        self.assertEqual(zone.format_auto_serial(datetime.now().timestamp()), today)
+
+        zone.soa_serial = today
+        self.assertEqual(zone.format_auto_serial(datetime.now().timestamp()), today + 1)
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "netbox_dns": {
+                **settings.PLUGINS_CONFIG["netbox_dns"],
+                "zone_soa_serial_format": "date-counter",
+            }
+        }
+    )
+    def test_date_counter_soa_serial_new_day(self):
+        zone = self.zones[0]
+        zone.soa_serial = 2020010199
+
+        self.assertEqual(
+            zone.format_auto_serial(datetime.now().timestamp()),
+            int(datetime.now().strftime("%Y%m%d00")),
+        )
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "netbox_dns": {
+                **settings.PLUGINS_CONFIG["netbox_dns"],
+                "zone_soa_serial_format": "date-counter",
+            }
+        }
+    )
+    def test_date_counter_soa_serial_daily_limit(self):
+        zone = self.zones[0]
+        zone.soa_serial = int(datetime.now().strftime("%Y%m%d99"))
+
+        with self.assertRaises(ValidationError):
+            zone.format_auto_serial(datetime.now().timestamp())
+
     def test_increase_soa_serial(self):
         zone = self.zones[1]
 


### PR DESCRIPTION
## Summary

Add an optional `date-counter` format for automatically generated SOA serial numbers. With `zone_soa_serial_format = 'date-counter'`, serials use `YYYYMMDDnn`; the existing Unix timestamp behavior remains the default.

## Details

- retain `unix` as the backward-compatible default
- validate the configured format during plugin startup
- reset the counter on a new day
- reject more than 100 automatic updates per zone and day with a clear validation error
- document configuration and behavior

## Tests

- initial date-based serial
- same-day counter increment
- counter reset on a new day
- daily limit validation
- Ruff lint and formatting checks
- `git diff --check`

## AI disclosure

The implementation, tests, and pull request description were created with AI assistance and reviewed by the submitter.