### PR TITLE
Fixed API tests failing due to missing object permissions

### DIFF
--- a/examples/custom-scripts/using_custom_scripts.md
+++ b/examples/custom-scripts/using_custom_scripts.md
@@ -194,22 +194,19 @@ A simple code example in python:
 import requests
 import json
 
-token = '<API_TOKEN>'
-nb_protocol = '<HTTP>'
-nb_host = '<NETBOX_HOST>'
-nb_port = '<NETBOX_PORT>'
+token = "<API_TOKEN>"
+nb_protocol = "<HTTP>"
+nb_host = "<NETBOX_HOST>"
+nb_port = "<NETBOX_PORT>"
 
 # Build the URL for the API request
-headers = {
-  'Content-Type': 'application/json',
-  'Authorization': 'Token '+ token
-}
+headers = {"Content-Type": "application/json", "Authorization": "Token " + token}
 
 ## Export IPAM to DNS -- CHANGE ID OF SCRIPT AND COMMIT IF NECESSARY
-url = nb_protocol+'://'+nb_host+':'+nb_port+"/api/extras/scripts/2/"
+url = nb_protocol + "://" + nb_host + ":" + nb_port + "/api/extras/scripts/2/"
 payload = '{"data": "vrf": null, "view": 1, "overwrite": true}, "commit": false}'
 
 response = requests.request("POST", url, headers=headers, data=payload)
 pretty_json = json.loads(response.text)
-print (json.dumps(pretty_json, indent=4))
+print(json.dumps(pretty_json, indent=4))
 ```

--- a/netbox_dns/tests/ipam_dnssync/test_ipam_api.py
+++ b/netbox_dns/tests/ipam_dnssync/test_ipam_api.py
@@ -453,6 +453,7 @@ class DNSsyncIPAMAPITestCase(APITestCase):
         self.assertEqual(record.zone, zone1)
 
         self.add_permissions("ipam.change_ipaddress")
+        self.add_permissions("ipam.view_vrf")
 
         url = reverse("ipam-api:ipaddress-detail", kwargs={"pk": ip_address.pk})
 
@@ -490,6 +491,7 @@ class DNSsyncIPAMAPITestCase(APITestCase):
         self.assertEqual(record.zone, zone)
 
         self.add_permissions("ipam.change_ipaddress")
+        self.add_permissions("ipam.view_vrf")
 
         url = reverse("ipam-api:ipaddress-detail", kwargs={"pk": ip_address.pk})
 

--- a/netbox_dns/tests/record/test_event_rules.py
+++ b/netbox_dns/tests/record/test_event_rules.py
@@ -211,6 +211,7 @@ class RecordEventRuleTest(APITestCase):
             "plugins-api:netbox_dns-api:record-detail", kwargs={"pk": record.pk}
         )
         self.add_permissions("netbox_dns.change_record")
+        self.add_permissions("extras.view_tag")
         data = {
             "tags": [
                 {"name": self.tags[0].name},
@@ -243,6 +244,7 @@ class RecordEventRuleTest(APITestCase):
             "plugins-api:netbox_dns-api:record-detail", kwargs={"pk": record.pk}
         )
         self.add_permissions("netbox_dns.change_record")
+        self.add_permissions("extras.view_tag")
         data = {
             "tags": [{"name": self.tags[0].name}],
         }

--- a/netbox_dns/tests/zone/test_event_rules.py
+++ b/netbox_dns/tests/zone/test_event_rules.py
@@ -134,6 +134,7 @@ class ZoneEventRuleTest(APITestCase):
 
         url = reverse("plugins-api:netbox_dns-api:zone-detail", kwargs={"pk": zone.pk})
         self.add_permissions("netbox_dns.change_zone")
+        self.add_permissions("netbox_dns.view_nameserver")
         data = {
             "nameservers": [
                 {"name": self.nameservers[1].name},
@@ -186,6 +187,7 @@ class ZoneEventRuleTest(APITestCase):
 
         url = reverse("plugins-api:netbox_dns-api:zone-detail", kwargs={"pk": zone.pk})
         self.add_permissions("netbox_dns.change_zone")
+        self.add_permissions("extras.view_tag")
         data = {
             "tags": [
                 {"name": self.tags[0].name},
@@ -214,6 +216,7 @@ class ZoneEventRuleTest(APITestCase):
 
         url = reverse("plugins-api:netbox_dns-api:zone-detail", kwargs={"pk": zone.pk})
         self.add_permissions("netbox_dns.change_zone")
+        self.add_permissions("extras.view_tag")
         data = {
             "tags": [{"name": self.tags[0].name}],
         }

--- a/netbox_dns/tests/zone/test_templating_api.py
+++ b/netbox_dns/tests/zone/test_templating_api.py
@@ -100,6 +100,7 @@ class ZoneTemplatingAPITestCase(APITestCase):
 
     def test_create_zone(self):
         self.add_permissions("netbox_dns.add_zone")
+        self.add_permissions("netbox_dns.view_zonetemplate")
         self.add_permissions("extras.view_tag")
 
         url = reverse("plugins-api:netbox_dns-api:zone-list")
@@ -145,7 +146,13 @@ class ZoneTemplatingAPITestCase(APITestCase):
 
     def test_create_zone_override_fields(self):
         self.add_permissions("netbox_dns.add_zone")
+        self.add_permissions("netbox_dns.view_dnssecpolicy")
+        self.add_permissions("netbox_dns.view_nameserver")
+        self.add_permissions("netbox_dns.view_registrar")
+        self.add_permissions("netbox_dns.view_registrationcontact")
+        self.add_permissions("netbox_dns.view_zonetemplate")
         self.add_permissions("extras.view_tag")
+        self.add_permissions("tenancy.view_tenant")
 
         url = reverse("plugins-api:netbox_dns-api:zone-list")
 
@@ -238,6 +245,7 @@ class ZoneTemplatingAPITestCase(APITestCase):
 
     def test_update_zone(self):
         self.add_permissions("netbox_dns.change_zone")
+        self.add_permissions("netbox_dns.view_zonetemplate")
 
         zone = Zone.objects.create(
             name="test.example.com",
@@ -280,6 +288,7 @@ class ZoneTemplatingAPITestCase(APITestCase):
 
     def test_create_zone_missing_soa_mname(self):
         self.add_permissions("netbox_dns.add_zone")
+        self.add_permissions("netbox_dns.view_zonetemplate")
         self.add_permissions("extras.view_tag")
 
         url = reverse("plugins-api:netbox_dns-api:zone-list")
@@ -297,6 +306,7 @@ class ZoneTemplatingAPITestCase(APITestCase):
 
         response = self.client.post(url, data, format="json", **self.header)
         self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+
         self.assertTrue(
             "soa_mname not set and no template or default value defined"
             in response.json().get("soa_mname")
@@ -304,6 +314,7 @@ class ZoneTemplatingAPITestCase(APITestCase):
 
     def test_create_zone_missing_soa_rname(self):
         self.add_permissions("netbox_dns.add_zone")
+        self.add_permissions("netbox_dns.view_zonetemplate")
         self.add_permissions("extras.view_tag")
 
         url = reverse("plugins-api:netbox_dns-api:zone-list")


### PR DESCRIPTION
Some new permission checks caused the test suite to fail with NetBox 4.6.5 and/or 4.6.6. 

This PR fixes the issue.